### PR TITLE
Whitespace only change, swap only tab for spaces

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-	"presets": ["es2015"],
+  "presets": ["es2015"],
   "compact": false
 }


### PR DESCRIPTION
It's the little things. Unless there's an undocumented reason for this sole tab character, let's just fit it. This PR ensures file syntax/format of this file matches all other files like it in the codebase.